### PR TITLE
Fix principals_options_for_select second argument

### DIFF
--- a/app/views/changeauthor/edit.html.erb
+++ b/app/views/changeauthor/edit.html.erb
@@ -9,7 +9,7 @@
 <p>
   <label><%= l(:head_authorchange) %></label>
   <select id="edit-authorid" name="authorid">
-    <%= principals_options_for_select(@users, @issue.author_id) %>
+    <%= principals_options_for_select(@users, @issue.author) %>
   </select>
 </p>
 </div>


### PR DESCRIPTION
hi.

Default selection of select box in edit view is always self.
Because, incorrect second argument of `principals_options_for_select`.

I tried to fix this problem.
Would you mind review my code?
