### PR TITLE
Removed Sidebar

### DIFF
--- a/app/views/changeauthor/edit.html.erb
+++ b/app/views/changeauthor/edit.html.erb
@@ -19,8 +19,4 @@
 
 <% html_title "#{@issue.tracker.name} ##{@issue.id}: #{@issue.subject}" %>
 
-<% content_for :sidebar do %>
-  <%= render :partial => 'issues/sidebar' %>
-<% end %>
-
 <%= context_menu issues_context_menu_path %>


### PR DESCRIPTION
This partial rendering killed the plugin as it can't get access to it. It seems to be outside of his scope. Haven't found a good variant to get to the scope. As the infos on the sidebar in this section won't be really necesarry.
